### PR TITLE
Hotfix/restore memoryleak

### DIFF
--- a/src/Wiz.Template.API/Middlewares/ErrorHandlerMiddleware.cs
+++ b/src/Wiz.Template.API/Middlewares/ErrorHandlerMiddleware.cs
@@ -15,20 +15,20 @@ namespace Wiz.Template.API.Middlewares
 {
     public class ErrorHandlerMiddleware
     {
-        private readonly ApplicationInsightsSettings _applicationInsights;
         private readonly IWebHostEnvironment _webHostEnvironment;
+        private readonly TelemetryClient _telemetry;
 
         public ErrorHandlerMiddleware(IOptions<ApplicationInsightsSettings> options, IWebHostEnvironment webHostEnvironment)
         {
-            _applicationInsights = options.Value;
             _webHostEnvironment = webHostEnvironment;
+            _telemetry = new TelemetryClient(new TelemetryConfiguration(options.Value.InstrumentationKey));
         }
 
         public async Task Invoke(HttpContext context)
         {
-            var telemetry = new TelemetryClient(new TelemetryConfiguration(_applicationInsights.InstrumentationKey));
+            
 
-            telemetry.Context.Operation.Id = Guid.NewGuid().ToString();
+            _telemetry.Context.Operation.Id = Guid.NewGuid().ToString();
 
             var ex = context.Features.Get<IExceptionHandlerFeature>()?.Error;
 
@@ -37,7 +37,7 @@ namespace Wiz.Template.API.Middlewares
                 return;
             }
 
-            telemetry.TrackException(ex);
+            _telemetry.TrackException(ex);
 
             var problemDetails = new ProblemDetails
             {

--- a/test/Wiz.Template.Contract.Tests/Wiz.Template.Contract.Tests.csproj
+++ b/test/Wiz.Template.Contract.Tests/Wiz.Template.Contract.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NJsonSchema" Version="10.3.3" />
+    <PackageReference Include="NJsonSchema" Version="10.3.11" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Wiz.Template.Integration.Tests/Wiz.Template.Integration.Tests.csproj
+++ b/test/Wiz.Template.Integration.Tests/Wiz.Template.Integration.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.2" />
-    <PackageReference Include="NJsonSchema" Version="10.3.3" />
+    <PackageReference Include="NJsonSchema" Version="10.3.11" />
     <PackageReference Include="ReportGenerator" Version="4.8.5 " />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
- Correção do memory leak localizado nos middlewares do template de API
- Correção na versão do NJsonSchema dos projetos de teste (Integração e Contrato), devido a incompatibilidades no momento de executar um restore.